### PR TITLE
Implemented the possibility to cache functions

### DIFF
--- a/src/target/typescript_nodeserver.cr
+++ b/src/target/typescript_nodeserver.cr
@@ -146,7 +146,7 @@ END
       @io << ident ident "if (cacheConfig.#{op.pretty_name}) {"
       @io << ident ident ident "try {\n"
       @io << ident ident ident ident "const {key, expirationSeconds, version} = await cacheConfig.#{op.pretty_name}(#{(["ctx"] + op.args.map(&.name)).join(", ")});\n"
-      @io << ident ident ident ident "if (!key) throw "";\n"
+      @io << ident ident ident ident "if (!key) throw \"\";\n"
       @io << ident ident ident ident "cacheKey = JSON.stringfy(key) + \"-#{op.pretty_name}\"; cacheExpirationSeconds = expiresSeconds; cacheVersion = version;"
       @io << ident ident ident ident "const cache = await hook.getCache(cacheKey, version);\n"
       @io << ident ident ident ident "if (cache && cache.expirationDate > new Date()) return cache.ret;\n"

--- a/src/target/typescript_nodeserver.cr
+++ b/src/target/typescript_nodeserver.cr
@@ -147,7 +147,7 @@ END
       @io << ident ident ident "try {\n"
       @io << ident ident ident ident "const {key, expirationSeconds, version} = await cacheConfig.#{op.pretty_name}(#{(["ctx"] + op.args.map(&.name)).join(", ")});\n"
       @io << ident ident ident ident "if (!key) throw \"\";\n"
-      @io << ident ident ident ident "cacheKey = JSON.stringfy(key) + \"-#{op.pretty_name}\"; cacheExpirationSeconds = expiresSeconds; cacheVersion = version;"
+      @io << ident ident ident ident "cacheKey = JSON.stringfy(key) + \"-#{op.pretty_name}\"; cacheExpirationSeconds = expirationSeconds; cacheVersion = version;"
       @io << ident ident ident ident "const cache = await hook.getCache(cacheKey, version);\n"
       @io << ident ident ident ident "if (cache && cache.expirationDate > new Date()) return cache.ret;\n"
       @io << ident ident ident "} catch(e) {}\n"
@@ -155,7 +155,7 @@ END
       @io << ident ident "const ret = await fn.#{op.pretty_name}(#{(["ctx"] + op.args.map(&.name)).join(", ")});\n"
       @io << ident ident op.return_type.typescript_check_decoded("ret", "\"#{op.pretty_name}.ret\"")
       @io << ident ident "const encodedRet = " + op.return_type.typescript_encode("ret") + ";\n"
-      @io << ident ident "if (cacheKey !== null && cacheVersion !== null) hook.setCache(cacheKey, new Date(new Date().getTime() + cacheExpirationSeconds), cacheVersion, encodedRet)"
+      @io << ident ident "if (cacheKey !== null && cacheVersion !== null && cacheExpirationSeconds !== null) hook.setCache(cacheKey, new Date(new Date().getTime() + cacheExpirationSeconds), cacheVersion, encodedRet)"
       @io << ident ident "return encodedRet"
       @io << ident "},\n"
     end

--- a/src/target/typescript_nodeserver.cr
+++ b/src/target/typescript_nodeserver.cr
@@ -123,16 +123,6 @@ END
     end
     @io << "};\n\n"
 
-    @ast.struct_types.each do |t|
-      @io << t.typescript_definition
-      @io << "\n\n"
-    end
-
-    @ast.enum_types.each do |t|
-      @io << t.typescript_definition
-      @io << "\n\n"
-    end
-
     @io << "const fnExec: {[name: string]: (ctx: Context, args: any) => Promise<any>} = {\n"
     @ast.operations.each do |op|
       @io << "    " << op.pretty_name << ": async (ctx: Context, args: any) => {\n"
@@ -147,7 +137,7 @@ END
       @io << ident ident ident "try {\n"
       @io << ident ident ident ident "const {key, expirationSeconds, version} = await cacheConfig.#{op.pretty_name}(#{(["ctx"] + op.args.map(&.name)).join(", ")});\n"
       @io << ident ident ident ident "if (!key) throw \"\";\n"
-      @io << ident ident ident ident "cacheKey = JSON.stringfy(key) + \"-#{op.pretty_name}\"; cacheExpirationSeconds = expirationSeconds; cacheVersion = version;"
+      @io << ident ident ident ident "cacheKey = JSON.stringify(key) + \"-#{op.pretty_name}\"; cacheExpirationSeconds = expirationSeconds; cacheVersion = version;"
       @io << ident ident ident ident "const cache = await hook.getCache(cacheKey, version);\n"
       @io << ident ident ident ident "if (cache && cache.expirationDate > new Date()) return cache.ret;\n"
       @io << ident ident ident "} catch(e) {}\n"
@@ -155,7 +145,7 @@ END
       @io << ident ident "const ret = await fn.#{op.pretty_name}(#{(["ctx"] + op.args.map(&.name)).join(", ")});\n"
       @io << ident ident op.return_type.typescript_check_decoded("ret", "\"#{op.pretty_name}.ret\"")
       @io << ident ident "const encodedRet = " + op.return_type.typescript_encode("ret") + ";\n"
-      @io << ident ident "if (cacheKey !== null && cacheVersion !== null && cacheExpirationSeconds !== null) hook.setCache(cacheKey, new Date(new Date().getTime() + cacheExpirationSeconds), cacheVersion, encodedRet)"
+      @io << ident ident "if (cacheKey !== null && cacheVersion !== null && cacheExpirationSeconds !== null) hook.setCache(cacheKey, new Date(new Date().getTime() + cacheExpirationSeconds), cacheVersion, encodedRet);\n"
       @io << ident ident "return encodedRet"
       @io << ident "},\n"
     end

--- a/src/target/typescript_nodeserver.cr
+++ b/src/target/typescript_nodeserver.cr
@@ -95,6 +95,23 @@ function toDateTimeString(date: Date) {
 
 END
 
+    @io << "export const cacheConfig: {\n"
+    @ast.operations.each do |op|
+      args = ["ctx: Context"] + op.args.map { |arg| "#{arg.name}: #{arg.type.typescript_native_type}" }
+      @io << "    " << op.pretty_name << "?: (#{args.join(", ")}) => Promise<{key: any, expirationSeconds: number, version: number}>;\n"
+    end
+    @io << "} = {};\n\n"
+
+    @ast.struct_types.each do |t|
+      @io << t.typescript_definition
+      @io << "\n\n"
+    end
+
+    @ast.enum_types.each do |t|
+      @io << t.typescript_definition
+      @io << "\n\n"
+    end
+
     @io << "export const fn: {\n"
     @ast.operations.each do |op|
       args = ["ctx: Context"] + op.args.map { |arg| "#{arg.name}: #{arg.type.typescript_native_type}" }
@@ -124,9 +141,22 @@ END
         @io << ident ident "const #{arg.name} = #{arg.type.typescript_decode("args.#{arg.name}")};"
         @io << "\n"
       end
+      @io << "\n"
+      @io << ident ident "let cacheKey: string | null = null, cacheExpirationSeconds: number | null = null, cacheVersion: number | null = null;"
+      @io << ident ident "if (cacheConfig.#{op.pretty_name}) {"
+      @io << ident ident ident "try {\n"
+      @io << ident ident ident ident "const {key, expirationSeconds, version} = await cacheConfig.#{op.pretty_name}(#{(["ctx"] + op.args.map(&.name)).join(", ")});\n"
+      @io << ident ident ident ident "if (!key) throw "";\n"
+      @io << ident ident ident ident "cacheKey = JSON.stringfy(key) + \"-#{op.pretty_name}\"; cacheExpirationSeconds = expiresSeconds; cacheVersion = version;"
+      @io << ident ident ident ident "const cache = await hook.getCache(cacheKey, version);\n"
+      @io << ident ident ident ident "if (cache && cache.expirationDate > new Date()) return cache.ret;\n"
+      @io << ident ident ident "} catch(e) {}\n"
+      @io << ident ident "}\n"
       @io << ident ident "const ret = await fn.#{op.pretty_name}(#{(["ctx"] + op.args.map(&.name)).join(", ")});\n"
       @io << ident ident op.return_type.typescript_check_decoded("ret", "\"#{op.pretty_name}.ret\"")
-      @io << ident ident "return " + op.return_type.typescript_encode("ret") + ";\n"
+      @io << ident ident "const encodedRet = " + op.return_type.typescript_encode("ret") + ";\n"
+      @io << ident ident "if (cacheKey !== null && cacheVersion !== null) hook.setCache(cacheKey, new Date(new Date().getTime() + cacheExpirationSeconds), cacheVersion, encodedRet)"
+      @io << ident ident "return encodedRet"
       @io << ident "},\n"
     end
     @io << "};\n\n"
@@ -205,11 +235,15 @@ export const hook: {
     onDevice: (id: string, deviceInfo: any) => Promise<void>
     onReceiveCall: (call: DBApiCall) => Promise<DBApiCall | void>
     afterProcessCall: (call: DBApiCall) => Promise<void>
+    setCache: (cacheKey: string, expirationDate: Date, version: number, ret: any) => Promise<void>
+    getCache: (cacheKey: string, version: number) => Promise<{expirationDate: Date, ret: any} | null>
 } = {
     onHealthCheck: async () => true,
     onDevice: async () => {},
     onReceiveCall: async () => {},
-    afterProcessCall: async () => {}
+    afterProcessCall: async () => {},
+    setCache: async () => {},
+    getCache: async () => null
 };
 
 export function start(port: number = 8000) {


### PR DESCRIPTION
With this PR we can set a cache key, version and expirationDate to any function we would like to cache it. 
The methods `hook.getCache` and `hook.setCache` must be implemented in the application