### PR TITLE
Add tags per version with branch name

### DIFF
--- a/target-web/build_and_publish.sh
+++ b/target-web/build_and_publish.sh
@@ -10,6 +10,7 @@ cd /root/stage
 export PATH=$(npm bin):$PATH
 json -I -f package.json -e 'this.name="@cubos/'$NAME'"'
 npm version $VERSION || true
+npm dist-tag add @cubos/$NAME@$CI_COMMIT_REF_NAME || true
 echo "[tsc] START"
 tsc
 echo "[tsc] END"


### PR DESCRIPTION
As previously discussed, this PR adds a tag to each released version, with the branch that generated it as its name. This intends to make it easier for apps consuming generated APIs not to install improper package versions accidentally, as production and develop versions share the same semver space.

As of now the tag is always added, maybe this should be behind a flag? 