### PR TITLE
fix: get rid of deprecated OptionParser.parse!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 
-FROM crystallang/crystal:0.27.0
+FROM crystallang/crystal:0.31.1
 ADD . /tmp/
 WORKDIR /tmp
 RUN crystal tool format --check
 RUN crystal spec
 RUN crystal build main.cr -o sdkgen
 
-FROM crystallang/crystal:0.27.0
+FROM crystallang/crystal:0.31.1
 CMD ["bash"]
 COPY --from=0 /tmp/sdkgen /usr/bin

--- a/src/main.cr
+++ b/src/main.cr
@@ -16,7 +16,7 @@ destination = ""
 target_name = ""
 sources = [] of String
 
-OptionParser.parse! do |parser|
+OptionParser.parse do |parser|
   parser.banner = "Usage: salute [arguments]"
   parser.on("-o NAME", "--output=NAME", "Specifies the output file") { |name| destination = name }
   parser.on("-t TARGET", "--target=TARGET", "Specifies the target platform") { |target| target_name = target }


### PR DESCRIPTION
https://crystal-lang.org/api/0.31.1/OptionParser.html#parse!-instance-method

Current crystal version throws the following warning:
```
 19 | OptionParser.parse! do |parser|
                   ^-----
Warning: Deprecated OptionParser.parse!. Use `parse` instead.

```