### PR TITLE
Public modifiers and MoneyPrimitiveType

### DIFF
--- a/src/target/swift.cr
+++ b/src/target/swift.cr
@@ -55,11 +55,11 @@ abstract class SwiftTarget < Target
 
   def generate_struct_type(t)
     String.build do |io|
-      io << "class #{t.name}: Codable {\n"
+      io << "public class #{t.name}: Codable {\n"
       t.fields.each do |field|
-        io << ident "var #{field.name}: #{native_type field.type}\n"
+        io << ident "public var #{field.name}: #{native_type field.type}\n"
       end
-      io << ident "\nvar copy: #{t.name} {\n"
+      io << ident "\npublic var copy: #{t.name} {\n"
       io << ident ident "return #{t.name}(\n"
       io << ident ident ident t.fields.map { |field| "#{field.name}: #{generate_property_copy(field.type, field.name)}" }.join(",\n")
       io << ident ident "\n)\n"
@@ -74,7 +74,7 @@ abstract class SwiftTarget < Target
       io << ident <<-END
 
 
-init() {
+public init() {
 
 END
       t.fields.each do |field|
@@ -83,7 +83,7 @@ END
       io << ident <<-END
 }
 
-init(#{t.fields.map { |f| "#{f.name}: #{native_type f.type}" }.join(", ")}) {
+public init(#{t.fields.map { |f| "#{f.name}: #{native_type f.type}" }.join(", ")}) {
 
 END
       t.fields.each do |field|
@@ -92,7 +92,7 @@ END
       io << ident <<-END
 }
 
-init(json: [String: Any]) throws {
+public init(json: [String: Any]) throws {
     let jsonData = try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
     let decodedSelf = try decoder.decode(#{t.name}.self, from: jsonData)\n
 
@@ -103,7 +103,7 @@ END
       io << ident <<-END
 }
 
-func toJSON() -> [String: Any] {
+public func toJSON() -> [String: Any] {
     var json = [String: Any]()
 
 END
@@ -122,9 +122,9 @@ END
   def generate_enum_type(t)
     String.build do |io|
       if t.name == "ErrorType"
-        io << "enum #{t.name}: String, Error, Codable {\n"
+        io << "public enum #{t.name}: String, Error, Codable {\n"
       else
-        io << "enum #{t.name}: String, CaseIterable, DisplayableValue, Codable {\n"
+        io << "public enum #{t.name}: String, CaseIterable, DisplayableValue, Codable {\n"
       end
 
       t.values.each do |value|
@@ -142,7 +142,7 @@ END
         io << ident ident "return dictionary\n"
         io << ident "}\n"
 
-        io << ident "\nstatic func allDisplayableValues() -> [String] {\n"
+        io << ident "\npublic static func allDisplayableValues() -> [String] {\n"
         io << ident ident "var displayableValues: [String] = []\n"
         io << ident ident "for enumCase in self.allCases {\n"
         io << ident ident ident "displayableValues.append(enumCase.displayableValue)\n"

--- a/src/target/swift.cr
+++ b/src/target/swift.cr
@@ -12,6 +12,7 @@ abstract class SwiftTarget < Target
     when AST::BoolPrimitiveType    ; "Bool"
     when AST::BytesPrimitiveType   ; "Data"
     when AST::VoidPrimitiveType    ; "NoReply"
+    when AST::MoneyPrimitiveType   ; "Int64"
     else
       raise "BUG! Should handle primitive #{t.class}"
     end
@@ -38,6 +39,7 @@ abstract class SwiftTarget < Target
     when AST::StringPrimitiveType  ; path
     when AST::IntPrimitiveType     ; path
     when AST::UIntPrimitiveType    ; path
+    when AST::MoneyPrimitiveType   ; path
     when AST::FloatPrimitiveType   ; path
     when AST::DatePrimitiveType    ; path
     when AST::DateTimePrimitiveType; path
@@ -158,7 +160,7 @@ END
     case t
     when AST::StringPrimitiveType
       "\"\""
-    when AST::IntPrimitiveType, AST::UIntPrimitiveType, AST::FloatPrimitiveType
+    when AST::IntPrimitiveType, AST::UIntPrimitiveType, AST::FloatPrimitiveType, AST::MoneyPrimitiveType
       "0"
     when AST::BoolPrimitiveType
       "false"
@@ -185,7 +187,7 @@ END
 
   def type_to_json(t : AST::Type, src : String)
     case t
-    when AST::StringPrimitiveType, AST::IntPrimitiveType, AST::UIntPrimitiveType, AST::FloatPrimitiveType, AST::BoolPrimitiveType
+    when AST::StringPrimitiveType, AST::IntPrimitiveType, AST::UIntPrimitiveType, AST::FloatPrimitiveType, AST::BoolPrimitiveType, AST::MoneyPrimitiveType
       "#{src}"
     when AST::DatePrimitiveType
       "apiInternal.encodeDate(date: #{src})"

--- a/src/target/swift_ios.cr
+++ b/src/target/swift_ios.cr
@@ -6,7 +6,7 @@ class SwiftIosTarget < SwiftTarget
 import Alamofire
 import KeychainSwift
 
-protocol ApiCallsLogic: class {\n
+public protocol ApiCallsLogic: class {\n
 END
 
     @ast.operations.each do |op|
@@ -24,18 +24,18 @@ END
     @io << "}\n\n" # CloseAPICallsProtocol
     @io << <<-END
 
-class API {
-    static var customUrl: String?
-    static var useStaging = false
-    static var globalCallback: (_ method: String, _ result: ApiInternal.Result<Any?>, _ callback: ((ApiInternal.Result<Any?>) -> Void)?) -> Void = { _, result, callback in
+public class API {
+    public static var customUrl: String?
+    public static var useStaging = false
+    public static var globalCallback: (_ method: String, _ result: ApiInternal.Result<Any?>, _ callback: ((ApiInternal.Result<Any?>) -> Void)?) -> Void = { _, result, callback in
         callback?(result)
     }
 
-    static var isEnabledAssertion = true
-    static var calls: ApiCallsLogic = Calls()
-    static var apiInternal = ApiInternal()
+    public static var isEnabledAssertion = true
+    public static var calls: ApiCallsLogic = Calls()
+    public static var apiInternal = ApiInternal()
 
-    static var decoder: JSONDecoder = {
+    public static var decoder: JSONDecoder = {
         let currentDecoder = JSONDecoder()
         currentDecoder.dateDecodingStrategy = .custom({ (decoder) -> Date in
             let container = try decoder.singleValueContainer()
@@ -54,7 +54,7 @@ class API {
     }()
 
      // MARK: Struct and Enums
-     struct NoReply: Codable {}\n\n
+     public struct NoReply: Codable {}\n\n
 END
     # ApiCalls
     @io << ident(String.build do |io|
@@ -102,20 +102,20 @@ END
 
     @io << <<-END
 
-    class ApiInternal {
+    public class ApiInternal {
         var baseUrl = #{@ast.options.url.inspect}
 
         // MARK: ApiInternal Inner classes
-        enum Result<T> {
+        public enum Result<T> {
             case success(T)
             case failure(Error)
         }
 
-        class Error: Codable {
+        public class Error: Codable {
             var type: API.ErrorType
             var message: String
 
-            init(type: API.ErrorType, message: String) {
+            public init(type: API.ErrorType, message: String) {
                 self.type = type
                 self.message = message
             }
@@ -299,11 +299,11 @@ END
         }
     }
 }
-protocol DisplayableValue: RawRepresentable {
+public protocol DisplayableValue: RawRepresentable {
     var displayableValue: String { get }
 }
 
-extension DisplayableValue where RawValue == String {
+public extension DisplayableValue where RawValue == String {
     var displayableValue: String {
         return self.rawValue
     }


### PR DESCRIPTION
Added MoneyPrimitiveType type as Int64 for swift_ios
Added `public` modifier on classes, enums, protocols, structs and its methods/variables. Needed for visibility accross modules on modularized apps