### PR TITLE
fix: handle 'aborted' http response event

### DIFF
--- a/src/target/typescript_nodeclient.cr
+++ b/src/target/typescript_nodeclient.cr
@@ -113,7 +113,10 @@ END
             reject({type: "BadFormattedResponse", message: `Response couldn't be parsed as JSON (${data}):\\n${e.toString()}`});
           }
         });
-
+        resp.on("aborted", () => {
+          console.error("Request aborted");
+          reject({type: "Fatal", message: "Request aborted"});
+        });
       });
 
       req.on("error", (e) => {


### PR DESCRIPTION
http response event 'aborted' was not being captured, leading to promise not being fulfilled.