### PR TITLE
fix: added a public initializer for NoReply struct

### DIFF
--- a/src/target/swift_ios.cr
+++ b/src/target/swift_ios.cr
@@ -53,8 +53,10 @@ public class API {
         return currentDecoder
     }()
 
-     // MARK: Struct and Enums
-     public struct NoReply: Codable {}\n\n
+    // MARK: Struct and Enums
+    public struct NoReply: Codable {
+        public init() {}
+    }\n\n
 END
     # ApiCalls
     @io << ident(String.build do |io|


### PR DESCRIPTION
Added a public initializer for struct `NoReply`. This is required for initialization of this struct on modularized apps because structs on different modules needs an init method with public visibility.

Use case:  When mocking Api calls for unit test purposes, sometimes we need to pass a NoReply instance to our mock repositories. 